### PR TITLE
[Image-Caching/#5] 이미지 압축 및 리사이징 기능 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/kolown/porring/MainActivity.kt
+++ b/app/src/main/java/com/kolown/porring/MainActivity.kt
@@ -66,6 +66,54 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    // Bitmap Factory 디코딩
+    // resizing
+    // 압축
+}
+
+@Composable
+fun ImagePicker() {
+    var imageUri by remember { mutableStateOf<Uri?>(null) }
+
+    // API 21 이상 사용: 일반 이미지 선택기
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let { imageUri = it }
+    }
+
+    // API 33 이상 사용: PhotoPicker
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri: Uri? ->
+        uri?.let { imageUri = it }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Button(onClick = {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                // API 33 이상에서 PhotoPicker 호출
+                photoPickerLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            } else {
+                // API 21 이상에서 일반 이미지 선택기 호출
+                imagePickerLauncher.launch("image/*")
+            }
+        }) {
+            Text(text = "Pick Image")
+        }
+
+        imageUri?.let {
+            AsyncImage(
+                model = it,
+                contentDescription = null
+            )
+        }
+
+    }
+
 }
 
 @Composable

--- a/app/src/main/java/com/kolown/porring/MainActivity.kt
+++ b/app/src/main/java/com/kolown/porring/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.kolown.porring
 
+import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -11,22 +13,28 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import coil3.compose.AsyncImage
 import com.kolown.porring.ui.theme.PorringTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 
@@ -38,10 +46,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             PorringTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                    val modifier = Modifier.padding(innerPadding)
+                    ImagePicker()
                 }
             }
         }
@@ -51,7 +57,7 @@ class MainActivity : ComponentActivity() {
         val file = File(applicationContext.cacheDir, "photo_${System.currentTimeMillis()}.jpg")
 
         FileOutputStream(file).use { outputStream ->
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)   // todo 상수 변환 필요
         }
 
         return Uri.fromFile(file)
@@ -66,9 +72,73 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    // Bitmap Factory 디코딩
-    // resizing
-    // 압축
+    fun decodeSampledBitmapFromUri(
+        context: Context,
+        uri: Uri
+    ): Bitmap? {
+        val options = BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            BitmapFactory.decodeStream(inputStream, null, options)
+        }
+
+        options.inSampleSize = calculateInSampleSize(options)
+
+        options.inJustDecodeBounds = false
+        return context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            BitmapFactory.decodeStream(inputStream, null, options)
+        }
+    }
+
+    private fun calculateInSampleSize(
+        options: BitmapFactory.Options
+    ): Int {
+        val (height: Int, width: Int) = options.run { outHeight to outWidth }
+        var inSampleSize = 1
+        // todo 상수 변환 필요(900, 720)
+
+        if (height > 900 || width > 720) {
+
+            val halfHeight: Int = height / 2
+            val halfWidth: Int = width / 2
+
+            while (halfHeight / inSampleSize >= 900 && halfWidth / inSampleSize >= 720) {
+                inSampleSize *= 2
+            }
+        }
+
+        return inSampleSize
+    }
+}
+
+// 편집 화면에서 사용할 Resizing 된 이미지
+// 필요시 수정해주세요
+@Composable
+fun ResizedImage(
+    context: Context,
+    uri: Uri,
+    decodeSampledBitmapFromResource: (Context, Uri) -> Bitmap?
+) {
+    // 이 bitmap을 편집하고 업로드할 때 이 bitmap을 업로드 하면 될듯
+    var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+
+    LaunchedEffect(uri) {
+        bitmap = withContext(Dispatchers.IO) {
+            decodeSampledBitmapFromResource(context, uri)
+        }
+    }
+
+    bitmap?.let {
+        AsyncImage(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(4f / 5f),  // todo 상수로 변환 필요
+            model = bitmap,
+            contentDescription = null,
+            contentScale = ContentScale.Crop
+        )
+    }
 }
 
 @Composable
@@ -95,10 +165,8 @@ fun ImagePicker() {
     ) {
         Button(onClick = {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                // API 33 이상에서 PhotoPicker 호출
                 photoPickerLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
             } else {
-                // API 21 이상에서 일반 이미지 선택기 호출
                 imagePickerLauncher.launch("image/*")
             }
         }) {
@@ -107,8 +175,11 @@ fun ImagePicker() {
 
         imageUri?.let {
             AsyncImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(4f / 5f),  // todo 상수로 변환 필요
                 model = it,
-                contentDescription = null
+                contentDescription = null,
             )
         }
 

--- a/app/src/main/java/com/kolown/porring/MainActivity.kt
+++ b/app/src/main/java/com/kolown/porring/MainActivity.kt
@@ -1,18 +1,34 @@
 package com.kolown.porring
 
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import coil3.compose.AsyncImage
 import com.kolown.porring.ui.theme.PorringTheme
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.File
+import java.io.FileOutputStream
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -30,6 +46,26 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    fun saveBitmapToCache(bitmap: Bitmap): Uri {
+        val file = File(applicationContext.cacheDir, "photo_${System.currentTimeMillis()}.jpg")
+
+        FileOutputStream(file).use { outputStream ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+        }
+
+        return Uri.fromFile(file)
+    }
+
+    fun clearCacheFiles() {
+        val cacheDir = applicationContext.cacheDir
+        if (cacheDir.isDirectory) {
+            cacheDir.listFiles()?.forEach { file ->
+                file.delete()
+            }
+        }
+    }
+
 }
 
 @Composable


### PR DESCRIPTION
## 주요 작업
- 찍은 사진의 uri 활용을 위하여 cacheDir을 이용한 이미지 캐싱
- Resizing 기능 구현
- 버전 별 앨범에서 사진 가져오기 구현

## 결과 화면
## 리뷰 요청 사항
- Resizing, Image Caching 로직이 어디에 있어야 하는 게 좋을까요?(MainActivity, ViewModel, UseCase...)
- 해상도를 720p로 설정하였는데 더 높은 해상도를 지원해야 할까요?

## 레퍼런스
- https://developer.android.com/training/data-storage/app-specific?hl=ko#external-access-files
- https://developer.android.com/reference/android/util/LruCache
- https://developer.android.com/topic/performance/graphics/cache-bitmap?hl=ko#disk-cache
- https://developer.android.com/codelabs/basic-android-kotlin-compose-load-images?hl=ko#5
- https://developer.android.com/topic/performance/graphics/load-bitmap?hl=ko