### PR TITLE
[My] Firestore 연결, post delete, state 처리

### DIFF
--- a/core/data/src/main/java/com/kolown/data/datasource/paging/UserPagingDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/paging/UserPagingDataSource.kt
@@ -29,8 +29,6 @@ class UserPagingDataSource @Inject constructor(
                 ?: closestPage?.nextKey?.page?.minus(1)
             UserPagingKey(page ?: 0, "")
         }
-
-//        return UserPagingKey(state.anchorPosition ?: 0, "")
     }
 
     override suspend fun load(params: LoadParams<UserPagingKey>): LoadResult<UserPagingKey, PostContentModel> {

--- a/core/data/src/main/java/com/kolown/data/datasource/paging/UserPagingDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/paging/UserPagingDataSource.kt
@@ -1,5 +1,6 @@
 package com.kolown.data.datasource.paging
 
+import android.app.usage.NetworkStatsManager
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.kolown.data.datasource.remote.PostDataSource
@@ -34,10 +35,15 @@ class UserPagingDataSource @Inject constructor(
     override suspend fun load(params: LoadParams<UserPagingKey>): LoadResult<UserPagingKey, PostContentModel> {
         val page = params.key?.page ?: 0
         val userId = params.key?.userId ?: ""
-        val posts = getPosts(userId, params)
+        val posts = getPosts(userId, params).getOrElse {
+            return LoadResult.Error(it)
+        }
+        val data = getData(posts).getOrElse {
+            return LoadResult.Error(it)
+        }
 
         return LoadResult.Page(
-            data = getData(posts),
+            data = data,
             prevKey = if (page == 0) null else UserPagingKey(page - 1, userId),
             nextKey = if (posts.isEmpty()) null else UserPagingKey(page + 1, userId)
         )
@@ -46,41 +52,43 @@ class UserPagingDataSource @Inject constructor(
     private suspend fun getPosts(
         userId: String,
         params: LoadParams<UserPagingKey>
-    ): List<PostModel> {
-        return postDataSource.getUserPost(userId, params.loadSize.toLong()).getOrThrow()
+    ): Result<List<PostModel>> {
+        return postDataSource.getUserPost(userId, params.loadSize.toLong())
     }
 
-    private suspend fun getData(posts: List<PostModel>): List<PostContentModel> {
-        val (tags, reactions) = coroutineScope {
-            val tagsDeferred =
-                async {
+    private suspend fun getData(posts: List<PostModel>): Result<List<PostContentModel>> {
+        return runCatching {
+            val (tags, reactions) = coroutineScope {
+                val tagsDeferred =
+                    async {
+                        posts.map {
+                            async {
+                                tagDataSource.getPostTag(it.postId).getOrThrow()
+                            }
+                        }.awaitAll()
+                    }
+                val reactionsDeferred = async {
                     posts.map {
                         async {
-                            tagDataSource.getPostTag(it.postId).getOrThrow()
+                            reactionDataSource.getReactionByPostId(it.postId).getOrThrow()
                         }
                     }.awaitAll()
                 }
-            val reactionsDeferred = async {
-                posts.map {
-                    async {
-                        reactionDataSource.getReactionByPostId(it.postId).getOrThrow()
-                    }
-                }.awaitAll()
+                tagsDeferred.await() to reactionsDeferred.await()
             }
-            tagsDeferred.await() to reactionsDeferred.await()
-        }
 
-        return posts.mapIndexed { index, postModel ->
-            PostContentModel(
-                postId = postModel.postId,
-                authorId = postModel.authorId,
-                imageUrl = postModel.imageUrl,
-                registerAt = postModel.registerAt,
-                description = postModel.description,
-                tags = tags[index].map { it.tagName },
-                isFollower = true,
-                reactions = reactions[index].mapNotNull { it.reaction },
-            )
+            posts.mapIndexed { index, postModel ->
+                PostContentModel(
+                    postId = postModel.postId,
+                    authorId = postModel.authorId,
+                    imageUrl = postModel.imageUrl,
+                    registerAt = postModel.registerAt,
+                    description = postModel.description,
+                    tags = tags[index].map { it.tagName },
+                    isFollower = true,
+                    reactions = reactions[index].mapNotNull { it.reaction },
+                )
+            }
         }
     }
 }

--- a/core/data/src/main/java/com/kolown/data/datasource/paging/UserPagingDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/paging/UserPagingDataSource.kt
@@ -6,6 +6,7 @@ import com.kolown.data.datasource.remote.PostDataSource
 import com.kolown.data.datasource.remote.ReactionDataSource
 import com.kolown.data.datasource.remote.TagDataSource
 import com.kolown.model.PostContentModel
+import com.kolown.model.PostModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -21,14 +22,37 @@ class UserPagingDataSource @Inject constructor(
     private val tagDataSource: TagDataSource,
     private val reactionDataSource: ReactionDataSource
 ) : PagingSource<UserPagingKey, PostContentModel>() {
-    override fun getRefreshKey(state: PagingState<UserPagingKey, PostContentModel>): UserPagingKey {
-        return UserPagingKey(state.anchorPosition ?: 0, "")
+    override fun getRefreshKey(state: PagingState<UserPagingKey, PostContentModel>): UserPagingKey? {
+        return state.anchorPosition?.let { position ->
+            val closestPage = state.closestPageToPosition(position)
+            val page = closestPage?.prevKey?.page?.plus(1)
+                ?: closestPage?.nextKey?.page?.minus(1)
+            UserPagingKey(page ?: 0, "")
+        }
+
+//        return UserPagingKey(state.anchorPosition ?: 0, "")
     }
 
     override suspend fun load(params: LoadParams<UserPagingKey>): LoadResult<UserPagingKey, PostContentModel> {
-        val page = params.key?.page ?: 1
+        val page = params.key?.page ?: 0
         val userId = params.key?.userId ?: ""
-        val posts = postDataSource.getUserPost(userId, params.loadSize.toLong()).getOrThrow()
+        val posts = getPosts(userId, params)
+
+        return LoadResult.Page(
+            data = getData(posts),
+            prevKey = if (page == 0) null else UserPagingKey(page - 1, userId),
+            nextKey = if (posts.isEmpty()) null else UserPagingKey(page + 1, userId)
+        )
+    }
+
+    private suspend fun getPosts(
+        userId: String,
+        params: LoadParams<UserPagingKey>
+    ): List<PostModel> {
+        return postDataSource.getUserPost(userId, params.loadSize.toLong()).getOrThrow()
+    }
+
+    private suspend fun getData(posts: List<PostModel>): List<PostContentModel> {
         val (tags, reactions) = coroutineScope {
             val tagsDeferred =
                 async {
@@ -48,21 +72,17 @@ class UserPagingDataSource @Inject constructor(
             tagsDeferred.await() to reactionsDeferred.await()
         }
 
-        return LoadResult.Page(
-            data = posts.mapIndexed { index, postModel ->
-                PostContentModel(
-                    postId = postModel.postId,
-                    authorId = postModel.authorId,
-                    imageUrl = postModel.imageUrl,
-                    registerAt = postModel.registerAt,
-                    description = postModel.description,
-                    tags = tags[index].map { it.tagName },
-                    isFollower = true,
-                    reactions = reactions[index].mapNotNull { it.reaction },
-                )
-            },
-            prevKey = if (page == 1) null else UserPagingKey(page - 1, userId),
-            nextKey = if (posts.isEmpty()) null else UserPagingKey(page + 1, userId)
-        )
+        return posts.mapIndexed { index, postModel ->
+            PostContentModel(
+                postId = postModel.postId,
+                authorId = postModel.authorId,
+                imageUrl = postModel.imageUrl,
+                registerAt = postModel.registerAt,
+                description = postModel.description,
+                tags = tags[index].map { it.tagName },
+                isFollower = true,
+                reactions = reactions[index].mapNotNull { it.reaction },
+            )
+        }
     }
 }

--- a/core/data/src/main/java/com/kolown/data/datasource/remote/PostDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/remote/PostDataSource.kt
@@ -156,7 +156,6 @@ class PostDataSourceImpl @Inject constructor(
 
     override suspend fun deletePost(postId: String): Result<Unit> {
         return runCatching {
-            throw Exception("Test")
             val documentId = postId.substringAfter("-")
             postCollection.document(documentId).delete().await()
         }

--- a/core/data/src/main/java/com/kolown/data/datasource/remote/PostDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/remote/PostDataSource.kt
@@ -21,7 +21,7 @@ interface PostDataSource {
         key: String?,
         perPage: Long
     ): Result<List<PostModel>>
-
+    suspend fun deletePost(postId: String): Result<Unit>
     suspend fun getUserFollowerPost(uid: String, perPage: Long): Result<List<PostModel>>
 }
 
@@ -154,4 +154,11 @@ class PostDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun deletePost(postId: String): Result<Unit> {
+        return runCatching {
+            throw Exception("Test")
+            val documentId = postId.substringAfter("-")
+            postCollection.document(documentId).delete().await()
+        }
+    }
 }

--- a/core/data/src/main/java/com/kolown/data/datasource/remote/ReactionDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/remote/ReactionDataSource.kt
@@ -7,6 +7,9 @@ import com.kolown.data.remote.ReactionDto
 import com.kolown.data.remote.toReactionModel
 import com.kolown.model.ReactionModel
 import com.kolown.model.Reactions
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.tasks.await
 import java.io.IOException
 import javax.inject.Inject
@@ -15,6 +18,7 @@ interface ReactionDataSource {
     suspend fun getReactionByPostId(postId: String): Result<List<ReactionModel>>
     suspend fun updatePostReaction(userId: String, postId: String, reaction: Reactions)
     suspend fun removePostReaction(userId: String, postId: String): Result<Unit>
+    suspend fun deletePostReaction(postId: String): Result<Unit>
 }
 
 class ReactionDataSourceImpl @Inject constructor(
@@ -70,6 +74,20 @@ class ReactionDataSourceImpl @Inject constructor(
             if (prevReaction.isEmpty) return Result.failure(IOException("리액션 없음"))
 
             prevReaction.forEach { it.reference.delete().await() }
+        }
+    }
+
+    override suspend fun deletePostReaction(postId: String): Result<Unit> {
+        return runCatching {
+            val reactions = reactionCollection.whereEqualTo("postId", postId).get().await()
+
+            coroutineScope {
+                reactions.documents.map {
+                    async {
+                        reactionCollection.document(it.id).delete().await()
+                    }
+                }.awaitAll()
+            }
         }
     }
 

--- a/core/data/src/main/java/com/kolown/data/datasource/remote/TagDataSource.kt
+++ b/core/data/src/main/java/com/kolown/data/datasource/remote/TagDataSource.kt
@@ -19,6 +19,7 @@ interface TagDataSource {
     suspend fun getPostTag(postId: String): Result<List<TagModel>>
     suspend fun getPostTagByTagId(tagId: String): Result<List<String>>
     suspend fun getTagBySearch(searchText: String,key:String?,perPage:Long) : Result<List<Tag>>
+    suspend fun deletePostTag(postId: String): Result<Unit>
 }
 
 class TagDataSourceImpl @Inject constructor(
@@ -128,6 +129,20 @@ class TagDataSourceImpl @Inject constructor(
                 }
             }
             tags.toList()
+        }
+    }
+
+    override suspend fun deletePostTag(postId: String): Result<Unit> {
+        return runCatching {
+            val postTags = postTagCollection.whereEqualTo("postId", postId).get().await()
+
+            coroutineScope {
+                postTags.documents.map {
+                    async {
+                        postTagCollection.document(it.id).delete().await()
+                    }
+                }.awaitAll()
+            }
         }
     }
 

--- a/core/data/src/main/java/com/kolown/data/mock/MockDataProvider.kt
+++ b/core/data/src/main/java/com/kolown/data/mock/MockDataProvider.kt
@@ -5,6 +5,8 @@ import com.kolown.model.FollowerThumbnail
 import com.kolown.model.Gallery
 import com.kolown.model.GalleryThumbnail
 import com.kolown.model.Post
+import com.kolown.model.PostContentModel
+import com.kolown.model.Reactions
 import com.kolown.model.Tag
 
 object MockDataProvider {
@@ -152,6 +154,18 @@ object MockDataProvider {
         galleryId = getRandomId(),
         imageUrl = getRandomImageUrl(),
         description = getRandomDescription()
+    )
+
+    fun getRandomGalleryPostContentModel() = PostContentModel(
+        postId = getRandomName(),
+        authorId = getRandomName(),
+        imageUrl = getRandomImageUrl(),
+        description = getRandomDescription(),
+        registerAt = "2023-01-01",
+        tags = listOf(getRandomTagName()),
+        isFollower = true,
+        reactions = listOf(Reactions.STAR),
+        myReaction = Reactions.STAR
     )
 
     fun getRandomPostList() = getRandomList {

--- a/core/data/src/main/java/com/kolown/data/repository/PostRepository.kt
+++ b/core/data/src/main/java/com/kolown/data/repository/PostRepository.kt
@@ -1,6 +1,7 @@
 package com.kolown.data.repository
 
 import android.net.Uri
+import android.util.Log
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -38,6 +39,7 @@ interface PostRepository {
     suspend fun removePostReaction(postId: String): Result<Unit>
     fun getUserPosts(userId: String? = null): Flow<PagingData<PostContentModel>>
     suspend fun getPostBySearch(tagId: String): Flow<PagingData<PostContentModel>>
+    suspend fun deletePost(postId: String): Flow<Boolean>
 }
 
 class PostRepositoryImpl @Inject constructor(
@@ -213,6 +215,46 @@ class PostRepositoryImpl @Inject constructor(
                 )
             }
         ).flow
+    }
+
+    override suspend fun deletePost(postId: String): Flow<Boolean> = flow {
+        coroutineScope {
+            val deletePostTagDeferred = async {
+                retryWithLimit {
+                    tagDataSource.deletePostTag(postId).getOrElse {
+                        throw IOException("포스트 태그 삭제 실패")
+                    }
+                }
+            }
+            val deleteReactionDeferred = async {
+                retryWithLimit {
+                    reactionDataSource.deletePostReaction(postId).getOrElse {
+                        throw IOException("리액션 삭제 실패")
+                    }
+                }
+            }
+            val deletePostDeferred = async {
+                retryWithLimit {
+                    postDataSource.deletePost(postId).getOrElse {
+                        throw IOException("게시물 삭제 실패")
+                    }
+                }
+            }
+
+            val results = awaitAll(
+                deletePostTagDeferred,
+                deleteReactionDeferred,
+                deletePostDeferred
+            )
+
+            val allSuccess = results.all { it.isSuccess }
+
+            if(allSuccess) {
+                emit(true)
+            } else {
+                throw IOException("하나 이상의 작업이 실패하였습니다.")
+            }
+        }
     }
 
     private suspend fun updateImageUrl(postId: String, fileUri: Uri): Result<Unit> {

--- a/core/data/src/main/java/com/kolown/data/repository/PostRepository.kt
+++ b/core/data/src/main/java/com/kolown/data/repository/PostRepository.kt
@@ -36,7 +36,7 @@ interface PostRepository {
     suspend fun getRandomDetailPostList(): Flow<PagingData<PostContentModel>>
     suspend fun reactPost(postId: String, reaction: Reactions): Result<Unit>
     suspend fun removePostReaction(postId: String): Result<Unit>
-    fun getUserPosts(userId: String): Flow<PagingData<PostContentModel>>
+    fun getUserPosts(userId: String? = null): Flow<PagingData<PostContentModel>>
     suspend fun getPostBySearch(tagId: String): Flow<PagingData<PostContentModel>>
 }
 
@@ -51,13 +51,20 @@ class PostRepositoryImpl @Inject constructor(
     private val userPagingDataSource: UserPagingDataSource,
 ) : PostRepository {
 
-    override fun getUserPosts(userId: String): Flow<PagingData<PostContentModel>> {
+    override fun getUserPosts(userId: String?): Flow<PagingData<PostContentModel>> {
+        val initialKey = if(userId == null) {
+            val authorId = googleAuthDataSource.getUserId()
+            UserPagingKey(0, authorId)
+        } else {
+            UserPagingKey(0, userId)
+        }
+
         return Pager(
             config = PagingConfig(
-                pageSize = 10,
+                pageSize = GALLERY_PAGE_SIZE,
                 enablePlaceholders = false
             ),
-            initialKey = UserPagingKey(1, userId),
+            initialKey = initialKey,
             pagingSourceFactory = { userPagingDataSource }
         ).flow
     }
@@ -240,5 +247,6 @@ class PostRepositoryImpl @Inject constructor(
     companion object {
         const val DETAIL_PER_PAGE = 2
         const val SEARCH_PER_PAGE = 5
+        const val GALLERY_PAGE_SIZE = 10
     }
 }

--- a/feature/home/src/main/java/com/kolown/home/component/RandomImageList.kt
+++ b/feature/home/src/main/java/com/kolown/home/component/RandomImageList.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -242,15 +243,14 @@ private fun RandomImage(
         }
 
         if (isError) {
-            Column {
-                Icon(
-                    imageVector = Icons.Default.Warning,
-                    contentDescription = null,
-                    tint = Color.Gray,
-                    modifier = Modifier.size(60.dp)
+            Box(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Text(
+                    modifier = Modifier.align(Alignment.Center),
+                    text = "이미지를 로드할 수 없음. 다시 시도해주세요."
                 )
             }
-
         }
     }
 

--- a/feature/my/build.gradle.kts
+++ b/feature/my/build.gradle.kts
@@ -66,4 +66,5 @@ dependencies {
     implementation(libs.androidx.foundation)
 
     implementation(projects.core.data)
+    implementation(projects.core.designsystem)
 }

--- a/feature/my/src/main/java/com/kolown/my/MyScreen.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyScreen.kt
@@ -1,30 +1,58 @@
 package com.kolown.my
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.kolown.model.PostContentModel
+import com.kolown.model.UiState
 import com.kolown.my.component.DeleteDialog
 import com.kolown.my.component.GalleryItem
 import com.kolown.my.component.MyAppBar
 import com.kolown.my.component.PageItemFooter
 import com.kolown.my.component.RestrictedLoginContent
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun MyRoute(
@@ -33,7 +61,7 @@ internal fun MyRoute(
     navigateToSetting: () -> Unit,
     padding: PaddingValues = PaddingValues(),
 ) {
-    if(isLoggedIn) {
+    if (isLoggedIn) {
         MyScreen(
             navigateToSetting = navigateToSetting,
             padding = padding
@@ -65,32 +93,107 @@ fun MyScreen(
         MyAppBar(
             onSettingClicked = navigateToSetting
         )
-        LazyVerticalStaggeredGrid(
-            columns = StaggeredGridCells.Fixed(2),
-            modifier = Modifier
-                .fillMaxSize(),
-            state = listState,
-            contentPadding = PaddingValues(8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalItemSpacing = 8.dp,
-            content = {
-                items(pagingItems.itemCount) { index ->
-                    pagingItems[index]?.let {
-                        GalleryItem(it, width) {
-                            viewModel.deletePost(it.postId)
-                        }
-                    }
-                }
-
-                if (pagingItems.loadState.append !is LoadState.NotLoading) {
-                    item(key = "", span = StaggeredGridItemSpan.FullLine) {
-                        PageItemFooter(loadState = pagingItems.loadState.append) {
-                            pagingItems.retry()
-                        }
-                    }
-                }
-            }
+        StateLazyGrid(
+            listState = listState,
+            pagingItems = pagingItems,
+            width = width,
+            deletePost = viewModel::deletePost
         )
+    }
+}
+
+@Composable
+fun StateLazyGrid(
+    listState: LazyStaggeredGridState,
+    pagingItems: LazyPagingItems<PostContentModel>,
+    width: Dp,
+    deletePost: (String) -> Unit,
+) {
+    var showErrorScreen by remember { mutableStateOf(false) }
+
+    LaunchedEffect(pagingItems.loadState.refresh) {
+        if (pagingItems.loadState.refresh == LoadState.Loading) {
+            delay(5000)
+            showErrorScreen = true
+        } else {
+            showErrorScreen = false
+        }
+    }
+
+
+    when  {
+        showErrorScreen -> {
+            ErrorScreen()
+        }
+        pagingItems.loadState.refresh is LoadState.Error -> {
+            Log.d("LazyVertical", "실패")
+            showErrorScreen = false
+            ErrorScreen()
+        }
+        pagingItems.loadState.refresh is LoadState.Loading -> {
+            Log.d("LazyVertical", "로딩")
+            showErrorScreen = false
+            Box(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .align(Alignment.Center),
+                )
+            }
+        }
+        pagingItems.loadState.refresh is LoadState.NotLoading -> {
+            Log.d("LazyVertical", "성공 ${pagingItems.itemCount}")
+            showErrorScreen = false
+            LazyVerticalStaggeredGrid(
+                columns = StaggeredGridCells.Fixed(2),
+                modifier = Modifier
+                    .fillMaxSize(),
+                state = listState,
+                contentPadding = PaddingValues(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalItemSpacing = 8.dp,
+                content = {
+                    items(pagingItems.itemCount) { index ->
+                        pagingItems[index]?.let {
+                            GalleryItem(it, width) {
+                                deletePost(it.postId)
+                            }
+                        }
+                    }
+
+                    if (pagingItems.loadState.append !is LoadState.NotLoading) {
+                        item(key = "", span = StaggeredGridItemSpan.FullLine) {
+                            PageItemFooter(loadState = pagingItems.loadState.append) {
+                                pagingItems.retry()
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Column(
+            modifier = Modifier.align(Alignment.Center),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                imageVector = Icons.Default.Warning, contentDescription = null
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "오류가 발생하였습니다!", color = Color.Red
+            )
+        }
     }
 }
 

--- a/feature/my/src/main/java/com/kolown/my/MyScreen.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.kolown.my.component.DeleteDialog
 import com.kolown.my.component.GalleryItem
 import com.kolown.my.component.MyAppBar
 import com.kolown.my.component.PageItemFooter
@@ -46,7 +49,6 @@ fun MyScreen(
     padding: PaddingValues = PaddingValues(),
     viewModel: MyViewModel = hiltViewModel(),
 ) {
-
     val width = LocalConfiguration.current.screenWidthDp.dp / 2
     val pagingItems = viewModel.galleryFlow.collectAsLazyPagingItems()
     val listState = rememberLazyStaggeredGridState()

--- a/feature/my/src/main/java/com/kolown/my/MyScreen.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyScreen.kt
@@ -74,7 +74,9 @@ fun MyScreen(
                 content = {
                     items(pagingItems.itemCount) { index ->
                         pagingItems[index]?.let {
-                            GalleryItem(it, width)
+                            GalleryItem(it, width) {
+                                viewModel.deletePost(it.postId)
+                            }
                         }
                     }
 

--- a/feature/my/src/main/java/com/kolown/my/MyScreen.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyScreen.kt
@@ -33,18 +33,19 @@ internal fun MyRoute(
     navigateToSetting: () -> Unit,
     padding: PaddingValues = PaddingValues(),
 ) {
-    MyScreen(
-        isLoggedIn = isLoggedIn,
-        navigateToLogin = navigateToLogin,
-        navigateToSetting = navigateToSetting,
-        padding = padding
-    )
+    if(isLoggedIn) {
+        MyScreen(
+            navigateToSetting = navigateToSetting,
+            padding = padding
+        )
+    } else {
+        RestrictedLoginContent(navigateToLogin)
+    }
+
 }
 
 @Composable
 fun MyScreen(
-    isLoggedIn: Boolean = false,
-    navigateToLogin: () -> Unit = {},
     navigateToSetting: () -> Unit = {},
     padding: PaddingValues = PaddingValues(),
     viewModel: MyViewModel = hiltViewModel(),
@@ -53,49 +54,44 @@ fun MyScreen(
     val pagingItems = viewModel.galleryFlow.collectAsLazyPagingItems()
     val listState = rememberLazyStaggeredGridState()
 
-    if (isLoggedIn) {
-        LaunchedEffect(pagingItems) {
-            listState.scrollToItem(0)
-        }
-        Column(
+    LaunchedEffect(pagingItems) {
+        listState.scrollToItem(0)
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+    ) {
+        MyAppBar(
+            onSettingClicked = navigateToSetting
+        )
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Fixed(2),
             modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
-            MyAppBar(
-                onSettingClicked = navigateToSetting
-            )
-            LazyVerticalStaggeredGrid(
-                columns = StaggeredGridCells.Fixed(2),
-                modifier = Modifier
-                    .fillMaxSize(),
-                state = listState,
-                contentPadding = PaddingValues(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalItemSpacing = 8.dp,
-                content = {
-                    items(pagingItems.itemCount) { index ->
-                        pagingItems[index]?.let {
-                            GalleryItem(it, width) {
-                                viewModel.deletePost(it.postId)
-                            }
-                        }
-                    }
-
-                    if (pagingItems.loadState.append !is LoadState.NotLoading) {
-                        item(key = "", span = StaggeredGridItemSpan.FullLine) {
-                            PageItemFooter(loadState = pagingItems.loadState.append) {
-                                pagingItems.retry()
-                            }
+                .fillMaxSize(),
+            state = listState,
+            contentPadding = PaddingValues(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalItemSpacing = 8.dp,
+            content = {
+                items(pagingItems.itemCount) { index ->
+                    pagingItems[index]?.let {
+                        GalleryItem(it, width) {
+                            viewModel.deletePost(it.postId)
                         }
                     }
                 }
-            )
-        }
-    } else {
-        RestrictedLoginContent(navigateToLogin)
-    }
 
+                if (pagingItems.loadState.append !is LoadState.NotLoading) {
+                    item(key = "", span = StaggeredGridItemSpan.FullLine) {
+                        PageItemFooter(loadState = pagingItems.loadState.append) {
+                            pagingItems.retry()
+                        }
+                    }
+                }
+            }
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
@@ -4,15 +4,15 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
-import androidx.paging.map
-import com.kolown.data.di.Fake
-import com.kolown.data.repository.GalleryRepository
+import androidx.paging.filter
 import com.kolown.data.repository.PostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,13 +20,18 @@ import javax.inject.Inject
 class MyViewModel @Inject constructor(
     private val postRepository: PostRepository,
 ) : ViewModel() {
-    val galleryFlow = postRepository.getUserPosts().cachedIn(viewModelScope)
+    private val deletedPostIds = MutableStateFlow<Set<String>>(emptySet())
+    private val originalGalleryFlow = postRepository.getUserPosts().cachedIn(viewModelScope)
+
+    val galleryFlow = combine(originalGalleryFlow, deletedPostIds) { pagingData, deletedIds ->
+        pagingData.filter { post -> post.postId !in deletedIds }
+    }
 
     fun deletePost(postId: String) {
         viewModelScope.launch {
             postRepository.deletePost(postId)
                 .onEach {
-
+                    deletedPostIds.update { deletedPostIds.value + postId }
                 }
                 .catch {
                     Log.e("GalleryItem", "deletePost error: $it")

--- a/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
@@ -23,11 +23,10 @@ class MyViewModel @Inject constructor(
     val galleryFlow = postRepository.getUserPosts().cachedIn(viewModelScope)
 
     fun deletePost(postId: String) {
-        Log.e("GalleryItem", "postId: $postId")
         viewModelScope.launch {
             postRepository.deletePost(postId)
                 .onEach {
-                    Log.e("GalleryItem", "deletePost: $it")
+
                 }
                 .catch {
                     Log.e("GalleryItem", "deletePost error: $it")

--- a/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
@@ -6,15 +6,15 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.kolown.data.di.Fake
 import com.kolown.data.repository.GalleryRepository
+import com.kolown.data.repository.PostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @HiltViewModel
 class MyViewModel @Inject constructor(
-    @Fake
-    private val galleryRepository: GalleryRepository
+    private val postRepository: PostRepository,
 ) : ViewModel() {
-    val galleryFlow = galleryRepository.getGalleryThumbnailPagingFlow(1).cachedIn(viewModelScope)
+    val galleryFlow = postRepository.getUserPosts().cachedIn(viewModelScope)
 
 }

--- a/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
+++ b/feature/my/src/main/java/com/kolown/my/MyViewModel.kt
@@ -1,5 +1,6 @@
 package com.kolown.my
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
@@ -8,7 +9,11 @@ import com.kolown.data.di.Fake
 import com.kolown.data.repository.GalleryRepository
 import com.kolown.data.repository.PostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -17,4 +22,17 @@ class MyViewModel @Inject constructor(
 ) : ViewModel() {
     val galleryFlow = postRepository.getUserPosts().cachedIn(viewModelScope)
 
+    fun deletePost(postId: String) {
+        Log.e("GalleryItem", "postId: $postId")
+        viewModelScope.launch {
+            postRepository.deletePost(postId)
+                .onEach {
+                    Log.e("GalleryItem", "deletePost: $it")
+                }
+                .catch {
+                    Log.e("GalleryItem", "deletePost error: $it")
+                }
+                .launchIn(viewModelScope)
+        }
+    }
 }

--- a/feature/my/src/main/java/com/kolown/my/component/DeleteDialog.kt
+++ b/feature/my/src/main/java/com/kolown/my/component/DeleteDialog.kt
@@ -1,0 +1,89 @@
+package com.kolown.my.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.kolown.designsystem.Error
+import com.kolown.designsystem.Primary
+
+@Composable
+fun DeleteDialog(
+    modifier: Modifier = Modifier,
+    onClickCancel: () -> Unit = {},
+    onClickConfirm: (String) -> Unit = {}
+) {
+    val textValue = remember { mutableStateOf("") }
+    Dialog(
+        onDismissRequest = { onClickCancel() },
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        )
+    ) {
+        Card(
+            modifier = modifier.size(
+                width = 380.dp,
+                height = 100.dp
+            ),
+            shape = RoundedCornerShape(10.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(text = "이 게시물을 삭제하시겠어요?", style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.height(20.dp))
+                Row {
+                    TextButton(
+                        onClick = onClickCancel,
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.White)
+                    ) {
+                        Text(text = "취소", color = Error)
+                    }
+                    TextButton(
+                        onClick = {
+                            onClickConfirm(textValue.value)
+                            onClickCancel()
+                        },
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.White)
+                    ) {
+                        Text(text = "삭제", color = Primary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DeleteDialogPreview() {
+    DeleteDialog()
+}

--- a/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
+++ b/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
@@ -2,21 +2,47 @@ package com.kolown.my.component
 
 import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import coil3.compose.AsyncImage
 import com.kolown.data.mock.MockDataProvider
+import com.kolown.designsystem.Error
+import com.kolown.designsystem.Primary
 import com.kolown.model.PostContentModel
 import kotlin.random.Random
 
@@ -29,6 +55,7 @@ fun GalleryItem(
 ) {
     //비율은 그냥 테스트
     val height = if (Random.nextBoolean()) (width.value * 1.4).dp else width + 20.dp
+    val isDialogVisible = remember { mutableStateOf(false) }
 
     AsyncImage(
         modifier = Modifier
@@ -40,7 +67,7 @@ fun GalleryItem(
                     // todo navigateToDetail
                 },
                 onLongClick = {
-                    onLongClickImage()
+                    isDialogVisible.value = true
                     Log.d("GalleryItem", "GalleryItem: LongClick")
                 }
             ),
@@ -48,6 +75,16 @@ fun GalleryItem(
         contentDescription = null,
         contentScale = ContentScale.Crop
     )
+
+    if(isDialogVisible.value) {
+        DeleteDialog(
+            onClickCancel = { isDialogVisible.value = false },
+            onClickConfirm = {
+                onLongClickImage()
+                isDialogVisible.value = false
+            }
+        )
+    }
 
 }
 

--- a/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
+++ b/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
@@ -54,7 +54,8 @@ fun GalleryItem(
     onLongClickImage: () -> Unit = {}
 ) {
     //비율은 그냥 테스트
-    val height = if (Random.nextBoolean()) (width.value * 1.4).dp else width + 20.dp
+    val heightNum = postContentModel.postId.filter { it.isDigit() }.toInt()
+    val height = if (heightNum % 2 == 0) (width.value * 1.4).dp else width + 20.dp
     val isDialogVisible = remember { mutableStateOf(false) }
 
     AsyncImage(

--- a/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
+++ b/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
@@ -2,10 +2,12 @@ package com.kolown.my.component
 
 import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,9 +17,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -25,8 +30,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,7 +49,9 @@ import androidx.compose.ui.window.DialogProperties
 import coil3.compose.AsyncImage
 import com.kolown.data.mock.MockDataProvider
 import com.kolown.designsystem.Error
+import com.kolown.designsystem.Gray
 import com.kolown.designsystem.Primary
+import com.kolown.designsystem.Surface2
 import com.kolown.model.PostContentModel
 import kotlin.random.Random
 
@@ -53,40 +62,74 @@ fun GalleryItem(
     width: Dp,
     onLongClickImage: () -> Unit = {}
 ) {
+    var isLoading by remember { mutableStateOf(true) }
+    var isError by remember { mutableStateOf(false) }
+
     //비율은 그냥 테스트
     val heightNum = postContentModel.postId.filter { it.isDigit() }.toInt()
     val height = if (heightNum % 2 == 0) (width.value * 1.4).dp else width + 20.dp
     val isDialogVisible = remember { mutableStateOf(false) }
 
-    AsyncImage(
-        modifier = Modifier
-            .fillMaxWidth()
+    Box(
+        modifier = Modifier.fillMaxWidth()
             .height(height)
             .clip(RoundedCornerShape(10.dp))
-            .combinedClickable (
-                onClick = {
-                    // todo navigateToDetail
-                },
-                onLongClick = {
-                    isDialogVisible.value = true
-                    Log.d("GalleryItem", "GalleryItem: LongClick")
-                }
-            ),
-        model = postContentModel.imageUrl,
-        contentDescription = null,
-        contentScale = ContentScale.Crop
-    )
-
-    if(isDialogVisible.value) {
-        DeleteDialog(
-            onClickCancel = { isDialogVisible.value = false },
-            onClickConfirm = {
-                onLongClickImage()
-                isDialogVisible.value = false
+            .background(Surface2)
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .fillMaxSize()
+                .combinedClickable (
+                    onClick = {
+                        // todo navigateToDetail
+                    },
+                    onLongClick = {
+                        isDialogVisible.value = true
+                        Log.d("GalleryItem", "GalleryItem: LongClick")
+                    }
+                ),
+            model = postContentModel.imageUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            onLoading = {
+                isLoading = true
+                isError = false
+            },
+            onSuccess = {
+                isLoading = false
+                isError = false
+            },
+            onError = {
+                isLoading = false
+                isError = true
             }
         )
-    }
 
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = Color.Gray,
+                modifier = Modifier.size(48.dp).align(Alignment.Center)
+            )
+        }
+
+        if (isError) {
+            Text(
+                modifier = Modifier.align(Alignment.Center),
+                text = "이미지를 로드할 수 없음.\n 다시 시도해주세요.",
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+
+        if(isDialogVisible.value) {
+            DeleteDialog(
+                onClickCancel = { isDialogVisible.value = false },
+                onClickConfirm = {
+                    onLongClickImage()
+                    isDialogVisible.value = false
+                }
+            )
+        }
+    }
 }
 
 @Preview

--- a/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
+++ b/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
@@ -1,29 +1,22 @@
 package com.kolown.my.component
 
-import android.util.Log
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
-import coil3.compose.AsyncImagePreviewHandler
 import com.kolown.data.mock.MockDataProvider
-import com.kolown.model.Gallery
-import com.kolown.model.GalleryThumbnail
+import com.kolown.model.PostContentModel
 import kotlin.random.Random
 
 @Composable
-fun GalleryItem(galleryThumbnail: GalleryThumbnail, width: Dp) {
+fun GalleryItem(postContentModel: PostContentModel, width: Dp) {
     //비율은 그냥 테스트
     val height = if (Random.nextBoolean()) (width.value * 1.4).dp else width + 20.dp
 
@@ -32,7 +25,7 @@ fun GalleryItem(galleryThumbnail: GalleryThumbnail, width: Dp) {
             .fillMaxWidth()
             .height(height)
             .clip(RoundedCornerShape(10.dp)),
-        model = galleryThumbnail.imageUrl,
+        model = postContentModel.imageUrl,
         contentDescription = null,
         contentScale = ContentScale.Crop
     )
@@ -42,5 +35,5 @@ fun GalleryItem(galleryThumbnail: GalleryThumbnail, width: Dp) {
 @Preview
 @Composable
 private fun GalleryItemPreview() {
-    GalleryItem(MockDataProvider.getRandomGalleryThumbnail(), 200.dp)
+    GalleryItem(MockDataProvider.getRandomGalleryPostContentModel(), 200.dp)
 }

--- a/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
+++ b/feature/my/src/main/java/com/kolown/my/component/GalleryItem.kt
@@ -1,11 +1,16 @@
 package com.kolown.my.component
 
+import android.util.Log
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -15,8 +20,13 @@ import com.kolown.data.mock.MockDataProvider
 import com.kolown.model.PostContentModel
 import kotlin.random.Random
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun GalleryItem(postContentModel: PostContentModel, width: Dp) {
+fun GalleryItem(
+    postContentModel: PostContentModel,
+    width: Dp,
+    onLongClickImage: () -> Unit = {}
+) {
     //비율은 그냥 테스트
     val height = if (Random.nextBoolean()) (width.value * 1.4).dp else width + 20.dp
 
@@ -24,7 +34,16 @@ fun GalleryItem(postContentModel: PostContentModel, width: Dp) {
         modifier = Modifier
             .fillMaxWidth()
             .height(height)
-            .clip(RoundedCornerShape(10.dp)),
+            .clip(RoundedCornerShape(10.dp))
+            .combinedClickable (
+                onClick = {
+                    // todo navigateToDetail
+                },
+                onLongClick = {
+                    onLongClickImage()
+                    Log.d("GalleryItem", "GalleryItem: LongClick")
+                }
+            ),
         model = postContentModel.imageUrl,
         contentDescription = null,
         contentScale = ContentScale.Crop

--- a/feature/their/src/main/java/com/kolown/their/TheirScreen.kt
+++ b/feature/their/src/main/java/com/kolown/their/TheirScreen.kt
@@ -41,43 +41,24 @@ internal fun TheirRoute(
     followerId: String,
     viewModel: TheirViewModel = hiltViewModel(),
 ) {
-    val followerName = viewModel.followerName.collectAsStateWithLifecycle()
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
-    val state = uiState.value
-
-    LaunchedEffect(followerName) {
+    LaunchedEffect(followerId) {
         viewModel.setFollowerName(followerId)
     }
-    LaunchedEffect(followerId) {
-        viewModel.getFollowerGallery(followerId)
-    }
 
-    when (state) {
-        is UiState.Loading -> {
-            Log.e("TheirRoute", "Loading: ${state}")
-        }
-        is UiState.Success -> {
-            Log.e("TheirRoute", "Success: ${state.data}")
-            val pagingItems = state.data.collectAsLazyPagingItems()
-            val pagerState = rememberLazyStaggeredGridState()
+    val followerName = viewModel.followerName.collectAsStateWithLifecycle()
+    val pagingItems = viewModel.galleryFlow.collectAsLazyPagingItems()
+    val pagerState = rememberLazyStaggeredGridState()
 
-            if(isLoggedIn) {
-                TheirScreen(
-                    popBackStack = popBackStack,
-                    padding = padding,
-                    followerName = followerName.value,
-                    pagingItems = pagingItems,
-                    pagerState = pagerState
-                )
-            } else {
-                RestrictedLoginContent(navigateToLogin)
-            }
-
-        }
-
-        is UiState.Failure -> {
-            Log.e("TheirRoute", "Error: ${state.error}")
-        }
+    if(isLoggedIn) {
+        TheirScreen(
+            popBackStack = popBackStack,
+            padding = padding,
+            followerName = followerName.value,
+            pagingItems = pagingItems,
+            pagerState = pagerState
+        )
+    } else {
+        RestrictedLoginContent(navigateToLogin)
     }
 }
 

--- a/feature/their/src/main/java/com/kolown/their/TheirViewModel.kt
+++ b/feature/their/src/main/java/com/kolown/their/TheirViewModel.kt
@@ -16,9 +16,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,23 +28,16 @@ class TheirViewModel @Inject constructor(
     private val postRepository: PostRepository,
     private val followRepository: FollowRepository
 ) : ViewModel() {
-    private val _uiState =
-        MutableStateFlow<UiState<Flow<PagingData<PostContentModel>>>>(UiState.Loading)
-    val uiState = _uiState.asStateFlow()
-
     private val _followerName = MutableStateFlow("Anonymous")
     val followerName = _followerName.asStateFlow()
 
-    fun getFollowerGallery(followerId: String) {
-        try {
-            _uiState.value =
-                UiState.Success(postRepository.getUserPosts(followerId).cachedIn(viewModelScope))
-        } catch (e: Exception) {
-            _uiState.value = UiState.Failure(e)
-        }
-    }
+    private val _userId = MutableStateFlow("")
+    val galleryFlow = _userId.flatMapLatest { userId ->
+        postRepository.getUserPosts(userId)
+    }.cachedIn(viewModelScope)
 
     fun setFollowerName(followerId: String) {
+        _userId.update { followerId }
         followRepository.getFollowerName(followerId)
             .onEach { _followerName.value = it }
             .catch {

--- a/feature/upload/src/main/java/com/kolown/upload/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/kolown/upload/UploadScreen.kt
@@ -83,10 +83,8 @@ internal fun UploadRoute(
         addCategory = viewModel::addCategory,
         removeCategory = viewModel::removeCategory,
         changeCategoryName = viewModel::changeCategoryName,
-        uploadPost = {
-            uploadPost(webPUri.toString(), description, categoryItems)
-            navigateToHome()
-        },
+        uploadPost = { uploadPost(webPUri.toString(), description, categoryItems) },
+        navigateToHome = navigateToHome
     )
 }
 
@@ -102,6 +100,7 @@ internal fun UploadScreen(
     removeCategory: (String) -> Unit = {},
     changeCategoryName: (Int, String) -> Unit = { _, _ -> },
     uploadPost: () -> Unit = {},
+    navigateToHome: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     val imeHeight = WindowInsets.ime.getBottom(LocalDensity.current)
@@ -126,7 +125,7 @@ internal fun UploadScreen(
             .padding(padding)
             .fillMaxSize()
     ) {
-        UploadTopAppBar()
+        UploadTopAppBar(navigateToHome = navigateToHome)
         UploadContent(
             imgUri = imgUri,
             modifier = Modifier
@@ -146,7 +145,10 @@ internal fun UploadScreen(
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .fillMaxWidth()
                 .height(40.dp),
-            onClick = uploadPost,
+            onClick = {
+                uploadPost()
+                navigateToHome()
+            },
             enabled = uploadEnable,
             shape = RoundedCornerShape(10.dp),
             colors = ButtonDefaults.buttonColors(containerColor = chooseColor(uploadEnable))
@@ -207,7 +209,9 @@ private fun UploadContent(
 }
 
 @Composable
-private fun UploadTopAppBar() {
+private fun UploadTopAppBar(
+    navigateToHome: () -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -216,7 +220,7 @@ private fun UploadTopAppBar() {
     ) {
         IconButton(
             modifier = Modifier.size(48.dp),
-            onClick = {}
+            onClick = { navigateToHome() }
         ) {
             Icon(
                 modifier = Modifier.size(36.dp),


### PR DESCRIPTION
## 주요 작업
- MyGallery 가져오기 Firestore 연동
- longpress시 포스트 삭제
- LoadResult, LoadState를 활용한 포스트 불러오기 성공, 실패, 로딩 처리
- Coil load 로딩, 실패 처리

## 리뷰 요청 사항
- 로딩이 길어져서 5초가 되면 error screen을 띄웁니다. error screen이 띄워져 있지만 성공으로 변경되면 데이터를 보여줍니다.
- Firebase에서 로컬 캐싱을 해서 url을 불러오지만 coil에서 아직 캐싱하지 못한 데이터는 이미지를 로드할 수 없다고 띄웁니다.
- 네트워크가 끊어진 상태였다가 다시 연결되면 recomposition을 하는 게 좋을지 고민입니다.
- 이 부분들 Notion에 적어두었으니 확인 부탁드립니다.